### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 # Azure Service Alerting Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-service-alerts/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-service-alerts/azurerm/)
 
 This Overlay terraform module can create [Azure Service Alerts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/alerts-service-health) and [Azure Monitor Alerts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/alerts-overview)
-with an [Action Group](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/action-groups) for notifications destination to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+with an [Action Group](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/action-groups) for notifications destination to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@
 
 # Azure Service Alerting Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-service-alerts/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-service-alerts/azurerm/)
 
 This Overlay terraform module can create [Azure Service Alerts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/alerts-service-health) and [Azure Monitor Alerts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/alerts-overview)
-with an [Action Group](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/action-groups) for notifications destination to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+with an [Action Group](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/action-groups) for notifications destination to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -6,5 +6,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  action_group_name = coalesce(var.custom_action_group_name, data.azurenoopsutils_resource_name.action_group.result)
+  action_group_name = coalesce(var.custom_action_group_name, data.popsrox_resource_name.action_group.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.use_naming
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "action_group" {
+data "popsrox_resource_name" "action_group" {
   name          = var.workload_name
   resource_type = "azurerm_monitor_action_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -12,7 +12,7 @@ data "azurenoopsutils_resource_name" "action_group" {
 }
 
 # Custom naming until managed by CAF provider
-data "azurenoopsutils_resource_name" "activity_log_alerts" {
+data "popsrox_resource_name" "activity_log_alerts" {
   for_each      = var.activity_log_alerts
   name          = var.workload_name
   resource_type = "azurerm_resource_group"
@@ -24,7 +24,7 @@ data "azurenoopsutils_resource_name" "activity_log_alerts" {
 }
 
 # Custom naming until managed by CAF provider
-data "azurenoopsutils_resource_name" "metric_alerts" {
+data "popsrox_resource_name" "metric_alerts" {
   for_each      = var.metric_alerts
   name          = var.workload_name
   resource_type = "azurerm_resource_group"

--- a/resources.service.alerts.activitylog.tf
+++ b/resources.service.alerts.activitylog.tf
@@ -4,7 +4,7 @@
 resource "azurerm_monitor_activity_log_alert" "activity_log_alert" {
   for_each = var.activity_log_alerts
 
-  name        = coalesce(each.value.custom_name, data.azurenoopsutils_resource_name.activity_log_alerts[each.key].result)
+  name        = coalesce(each.value.custom_name, data.popsrox_resource_name.activity_log_alerts[each.key].result)
   description = each.value.description
 
   resource_group_name = coalesce(each.value.resource_group_name, var.monitoring_resource_group_name)

--- a/resources.service.alerts.metricalerts.tf
+++ b/resources.service.alerts.metricalerts.tf
@@ -4,7 +4,7 @@
 resource "azurerm_monitor_metric_alert" "metric_alert" {
   for_each = var.metric_alerts
 
-  name        = coalesce(each.value.custom_name, data.azurenoopsutils_resource_name.metric_alerts[each.key].result)
+  name        = coalesce(each.value.custom_name, data.popsrox_resource_name.metric_alerts[each.key].result)
   description = each.value.description
 
   resource_group_name = coalesce(each.value.resource_group_name, var.monitoring_resource_group_name)

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Renames all `azurenoops` references to the new `POps-Rox` org identity across Terraform configuration and documentation files.

## Changes
- `versions.tf`: Renamed provider key `azurenoopsutils` → `popsrox-utils`; updated source from `azurenoops/azurenoopsutils` → `POps-Rox/azutils`
- `naming.tf`: Renamed all `data "azurenoopsutils_resource_name"` blocks → `data "popsrox_resource_name"`
- `locals.naming.tf`: Updated `data.azurenoopsutils_resource_name.*` references → `data.popsrox_resource_name.*`
- `resources.service.alerts.activitylog.tf`: Updated data source reference to `popsrox_resource_name`
- `resources.service.alerts.metricalerts.tf`: Updated data source reference to `popsrox_resource_name`
- `README.md`: Updated TF Registry badge and SCCA network links from `azurenoops` → `POps-Rox`
- `docs/index.md`: Same badge and link updates as README

## Testing
- Verified zero remaining `azurenoops` references across all .tf, .md, .yaml, and .json files
- `terraform fmt -recursive` ran clean with no formatting changes required

Closes #7