### PR TITLE
fix: resolve 4.x validation/CI failures

### DIFF
--- a/resources.service.alerts.activitylog.tf
+++ b/resources.service.alerts.activitylog.tf
@@ -7,6 +7,9 @@ resource "azurerm_monitor_activity_log_alert" "activity_log_alert" {
   name        = coalesce(each.value.custom_name, data.popsrox_resource_name.activity_log_alerts[each.key].result)
   description = each.value.description
 
+  # azurerm 4.x made `location` required for this resource. Activity log alerts
+  # are a global resource so `"global"` is the canonical value.
+  location            = "global"
   resource_group_name = coalesce(each.value.resource_group_name, var.monitoring_resource_group_name)
   scopes              = each.value.scopes
 


### PR DESCRIPTION
Post-merge fix for CI failures introduced by Phase 1 4.x migration.

**Failing job:** Terraform Validate
**Root cause:** `azurerm_monitor_activity_log_alert.location` became required in azurerm provider 4.x.
**Fix:** Set `location = "global"` (activity log alerts are a global resource in Azure).

Validated locally:
- `terraform fmt -recursive -check` ✅
- `terraform validate` (root) ✅
- `terraform validate` (examples/basic) ✅